### PR TITLE
AutoCrater:  Slowed driveDistance() to .1 to prevent drawbridge from …

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/AutoLinearOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/AutoLinearOpMode.java
@@ -86,6 +86,14 @@ public class AutoLinearOpMode extends LinearOpMode{
         LB.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
         RB.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
 
+        // TODO: One way to "hold" the deployment drawbridge in place, but needs encoder wired up
+        deployment.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
+/*
+        deployment.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        deployment.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        deployment.setTargetPosition(100); // Something small, no movement
+*/
+
 
         int relativeLayoutId = map.appContext.getResources().getIdentifier("RelativeLayout", "id", map.appContext.getPackageName());
         final View relativeLayout = ((Activity) map.appContext).findViewById(relativeLayoutId);
@@ -213,7 +221,10 @@ public class AutoLinearOpMode extends LinearOpMode{
         do {
             resetAngle();
 
-            telemetry.addData("imu heading", getAngle());
+            telemetry.addData("imu heading", "Delta Angle %.2f, Old Angle %.2f, Current Angle %.2f, Target angle %d",
+                    getAngle(), oldAngle.firstAngle,
+                    imu.getAngularOrientation(AxesReference.INTRINSIC, AxesOrder.ZYX, AngleUnit.DEGREES).firstAngle,
+                    target);
             telemetry.update();
 
             // getAngle() returns + when rotating counter clockwise (left) and - when rotating clockwise (right).

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Autonomous/AutoCrater.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Autonomous/AutoCrater.java
@@ -17,9 +17,13 @@ public class AutoCrater extends AutoLinearOpMode {
         boolean hit = false;
 
         waitForStart();
-           driveDistance(0.2,10); //move forward
+        // TODO: When encoders are wired for deployment drawbridge, then can treat it like a servo with starting and deployed positions
+        // TODO: Then just need to use deployment.setTargetPosition(Deploy|Start); and it will move back and forth to wherever it needs
+        // TODO: It will also hold it in place nicely, whereas now even setting to "BRAKE" doesn't stop it
+        //deployment.setPower(0.5); // RUN_TO_POSITION == 100, so will hold in place until needed
+           driveDistance(0.1,10); //move forward
            sleep(1000);
-           rotate(290,0.2); //Turn left
+           rotate(290,0.1); //Turn left
            sleep(1000);
           // driveDistance(-0.2, 9); //Back up to line up with the last mineral
            //sleep(1000);
@@ -38,11 +42,11 @@ public class AutoCrater extends AutoLinearOpMode {
            }*/
            //driveDistance(0.2, 20-dist); //Drive up next to the wall
         //driveDistance(0.2, 20);
-        driveDistance(0.2, 24);
+        driveDistance(0.1, 24);
         sleep(1000);
-        rotate(323, 0.2); //turn parallel to the wall
+        rotate(323, 0.1); //turn parallel to the wall
         sleep(1000 );
-        driveDistance(0.3, 28); //Move forward into the depot
+        driveDistance(0.2, 28); //Move forward into the depot
         sleep(1000);
         //openBox();
         sleep(1000);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MainTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MainTeleOp.java
@@ -84,10 +84,10 @@ public class MainTeleOp extends AutoLinearOpMode {
 
             //lift intake
             if(gamepad2.right_stick_y > 0.05){
-                deployment.setPower(0.3);
+                deployment.setPower(-0.3);
             //lower intake
             }else if(gamepad2.right_stick_y < -0.05){
-                deployment.setPower(-0.3);
+                deployment.setPower(0.3);
             }
             else{
                 deployment.setPower(0);
@@ -95,9 +95,10 @@ public class MainTeleOp extends AutoLinearOpMode {
 
             setMotorPowers(leftPower, rightPower);
 
-            telemetry.addData("Status", "Run Time: " + runtime.toString());
-            telemetry.addData("Motors", "left (%.2f), right (%.2f)", leftPower, rightPower);
-            telemetry.addData("Half Speed", halfSpeed);
+            telemetry.addData("Status", "Run Time: " + runtime.toString())
+                    .addData("Motors", "left (%.2f), right (%.2f)", leftPower, rightPower)
+                    .addData("Half Speed", halfSpeed)
+                    .addData("Deployment", "Power %.2f - Position %d", deployment.getPower(), deployment.getCurrentPosition());
             telemetry.update();
         }
     }


### PR DESCRIPTION
…deploying.

AutoLinearOpMode:  Tried setting ZeroPowerBehavior to deployment motor to BRAKE, but still deployed when robot stopped quickly.  Tried to use RUN_TO_POSITION to hold it in place, but there aren't any encoder wires for that motor.  Added some telemetry on the rotate() method to see why it was turning sometimes and other times not.

MainTeleOp: Fixed the power values for the deployment drawbridge so that pushing forward (negative gamepad values) actually lowers the drawbridge (positive power) and pulling back (positive gamepad values) actually raises the drawbridge (negative power).  Also added some telemetry to see values for the deployment drawbridge to see what power was getting set.

Before issuing a pull request, please see the contributing page.
